### PR TITLE
Moved the token Handling from url? to Request header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,22 +78,39 @@ GitHub.prototype.req = function (url, data, callback) {
 
     // Jsonreq on server, XHR on client
     if (typeof Jsonreq === "function") {
-        req = Jsonreq({
-            url: url
-            , Authentication: `Bearer ${self.token}`
-            , data: data
-            , headers: {
-                "User-agent": self.user_agent
-            }
-        }, function (err, data, res) {
-            self.checkResponse(err, data, res, callback);
-        });
+
+        if (self.token != null) {
+            req = Jsonreq({
+                url: url
+                , Authentication: `Bearer ${self.token}`
+                , data: data
+                , headers: {
+                    "User-agent": self.user_agent
+                }
+            }, function (err, data, res) {
+                self.checkResponse(err, data, res, callback);
+            });
+
+        }
+        else {
+            req = Jsonreq({
+                url: url
+                , data: data
+                , headers: {
+                    "User-agent": self.user_agent
+                }
+            }, function (err, data, res) {
+                self.checkResponse(err, data, res, callback);
+            });
+        }
     } else {
         req = new XMLHttpRequest();
         callback = callback || function () { };
-        
+
         req.open("GET", url, true);
-        req.setRequestHeader('Authorization', 'Bearer ' + self.token);
+        if (self.token != null) {
+            req.setRequestHeader('Authorization', 'Bearer ' + self.token);
+        }
         req.send();
         req.onreadystatechange = function () {
             if (req.readyState !== 4) { return; }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ if (typeof require === "undefined") {
     var require = function (pk) {
         if (pk === "ul") {
             return {
-                deepMerge: function () { var dst = {} , src , p , args = [].splice.call(arguments, 0) ; while (args.length > 0) { src = args.splice(-1)[0]; if (toString.call(src) != "[object Object]") { continue; } for (p in src) { if (!src.hasOwnProperty(p)) { continue; } if (toString.call(src[p]) == "[object Object]") { dst[p] = this.deepMerge(src[p], dst[p] || {}); } else { if (src[p] !== undefined) { dst[p] = src[p]; } }; } } return dst; }
+                deepMerge: function () { var dst = {}, src, p, args = [].splice.call(arguments, 0); while (args.length > 0) { src = args.splice(-1)[0]; if (toString.call(src) != "[object Object]") { continue; } for (p in src) { if (!src.hasOwnProperty(p)) { continue; } if (toString.call(src[p]) == "[object Object]") { dst[p] = this.deepMerge(src[p], dst[p] || {}); } else { if (src[p] !== undefined) { dst[p] = src[p]; } }; } } return dst; }
             };
         }
         if (pk === "querystring") {
@@ -23,9 +23,9 @@ if (typeof require === "undefined") {
 
 // Dependencies
 var Ul = require("ul")
-  , Jsonreq = require("jsonrequest")
-  , QueryString = require("querystring")
-  ;
+    , Jsonreq = require("jsonrequest")
+    , QueryString = require("querystring")
+    ;
 
 /**
  * GitHub
@@ -41,7 +41,7 @@ var Ul = require("ul")
  *
  * @return {GitHub} A new `GitHub` instance.
  */
-function GitHub (options) {
+function GitHub(options) {
     options = options || {};
     this.host = options.host || "https://api.github.com/";
     this.token = options.token;
@@ -61,9 +61,9 @@ function GitHub (options) {
  */
 GitHub.prototype.req = function (url, data, callback) {
     var self = this
-      , req = null
-      , url = self.host + url
-      ;
+        , req = null
+        , url = self.host + url
+        ;
 
     if (typeof data === "function") {
         callback = data;
@@ -71,17 +71,18 @@ GitHub.prototype.req = function (url, data, callback) {
     }
 
     // Handle the token
-    if (self.token) {
-        url += url.indexOf("?") > -1 ? "&" : "?";
-        url += "access_token=" + self.token;
-    }
+    // if (self.token) {
+    //     url += url.indexOf("?") > -1 ? "&" : "?";
+    //     url += "access_token=" + self.token;
+    // }
 
     // Jsonreq on server, XHR on client
     if (typeof Jsonreq === "function") {
         req = Jsonreq({
             url: url
-          , data: data
-          , headers: {
+            , Authentication: `Bearer ${self.token}`
+            , data: data
+            , headers: {
                 "User-agent": self.user_agent
             }
         }, function (err, data, res) {
@@ -89,10 +90,12 @@ GitHub.prototype.req = function (url, data, callback) {
         });
     } else {
         req = new XMLHttpRequest();
-        callback = callback || function () {};
+        callback = callback || function () { };
+        
         req.open("GET", url, true);
+        req.setRequestHeader('Authorization', 'Bearer ' + self.token);
         req.send();
-        req.onreadystatechange = function() {
+        req.onreadystatechange = function () {
             if (req.readyState !== 4) { return; }
             self.checkResponse(null, req.responseText, {
                 statusCode: req.status
@@ -143,10 +146,10 @@ GitHub.prototype.checkResponse = function (err, data, res, callback) {
 GitHub.prototype.get = function (url, options, callback) {
 
     var self = this
-      , page = 1
-      , doSeq = null
-      , allItems = null
-      ;
+        , page = 1
+        , doSeq = null
+        , allItems = null
+        ;
 
     if (typeof options === "function") {
         callback = options;
@@ -177,7 +180,7 @@ GitHub.prototype.get = function (url, options, callback) {
     }
 
     if (Object.keys(options.opts).length) {
-        url += "?";
+        url += url + "?";
     }
 
     return self.req(url + QueryString.stringify(options.opts), options.data, callback);


### PR DESCRIPTION
Github will deprecate authentication via URL query parameters in november 2020. instead of adding parameters in the url, we should set authentication parameters in the Header.